### PR TITLE
Enhance resume functionality: add top skills to initial state, improv…

### DIFF
--- a/src/components/ResumeFormSections/GeneralSection.vue
+++ b/src/components/ResumeFormSections/GeneralSection.vue
@@ -23,11 +23,11 @@
 
             <div>
                 <img
-                    :src="resumeStore.profilePhotoUrl"
+                    :src="resumeStore.general.profilePhoto"
                     :alt="getLocalizedString('profilePhoto')"
                     width="100"
                     height="100"
-                    v-if="resumeStore.profilePhotoUrl"
+                    v-if="resumeStore.general.profilePhoto"
                 />
             </div>
 

--- a/src/components/__tests__/ResumePreview.spec.ts
+++ b/src/components/__tests__/ResumePreview.spec.ts
@@ -195,6 +195,9 @@ describe('ResumePreview.vue', () => {
     });
 
     it('should throw an error when PDF generation fails', async () => {
+        console.error = vi.fn();
+        expect(console.error).toHaveBeenCalledTimes(0);
+
         vi.spyOn(pdfjsLib, 'getDocument').mockReturnValue({
             promise: Promise.resolve(),
         } as never);
@@ -216,8 +219,8 @@ describe('ResumePreview.vue', () => {
         await expect(instance.renderPDF()).rejects.toThrowError();
 
         // mock console.error
-        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-        expect(consoleError).toHaveBeenCalledTimes(0);
+        // const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        expect(console.error).toHaveBeenCalledTimes(3);
 
         const resumeStore = useResumeStore();
         resumeStore.general.name.firstName = 'Arya';
@@ -225,7 +228,7 @@ describe('ResumePreview.vue', () => {
 
         await flushPromises();
 
-        expect(consoleError).toHaveBeenCalledTimes(2);
+        expect(console.error).toHaveBeenCalledTimes(5);
     });
 
     it('should not follow the previous page when the current page is 1', async () => {

--- a/src/stores/__tests__/resume.spec.ts
+++ b/src/stores/__tests__/resume.spec.ts
@@ -73,9 +73,13 @@ describe('useResumeStore', () => {
         expect(store.formattedName).toBe('John Doe Smith');
     });
 
-    it('profilePhotoUrl getter returns the correct URL', () => {
+    it('formattedName getter returns the correct display name if present', () => {
         const store = useResumeStore();
-        expect(store.profilePhotoUrl).toBe('wrs.wesley.jpg');
+        store.general.name.firstName = 'John';
+        store.general.name.middleName = 'Doe';
+        store.general.name.lastName = 'Smith';
+        store.general.name.displayName = 'Johnny Smith';
+        expect(store.formattedName).toBe('Johnny Smith');
     });
 
     it('updateProfilePhoto action updates the profile photo', async () => {
@@ -83,6 +87,26 @@ describe('useResumeStore', () => {
         const file = new File([''], 'photo.jpg', { type: 'image/jpeg' });
         await store.updateProfilePhoto(file);
         expect(store.general.profilePhoto).toEqual('data:image/jpeg;base64,');
+    });
+
+    it('updateProfilePhoto action does not update the profile photo if the file is not an image', async () => {
+        console.error = vi.fn();
+
+        const store = useResumeStore();
+        store.clearProfilePhoto();
+
+        const file = new File([''], 'resume.pdf', { type: 'application/pdf' });
+        await store.updateProfilePhoto(file);
+
+        expect(store.general.profilePhoto).toBe('');
+        expect(console.error).toHaveBeenCalled();
+    });
+
+    it('clearProfilePhoto action clears the profile photo', () => {
+        const store = useResumeStore();
+        expect(store.general.profilePhoto).not.toBe('');
+        store.clearProfilePhoto();
+        expect(store.general.profilePhoto).toBe('');
     });
 
     it('updateName action updates the name', () => {
@@ -204,5 +228,56 @@ describe('useResumeStore', () => {
         const tools = ['Git', 'Docker'];
         store.updateSkillsTools(tools);
         expect(store.skills.tools).toEqual(tools);
+    });
+
+    it('addTopSkill action adds a top skill', () => {
+        const store = useResumeStore();
+        const skill = { name: 'JavaScript', yearsOfExperience: 5 };
+        expect(store.topSkills).toEqual([]);
+        store.addTopSkill(skill);
+        expect(store.topSkills).toEqual([skill]);
+    });
+
+    it('updateTopSkill action updates a top skill', () => {
+        const store = useResumeStore();
+        const skill = { name: 'JavaScript', yearsOfExperience: 5 };
+        store.addTopSkill(skill);
+        const updatedSkill = { name: 'TypeScript', yearsOfExperience: 3 };
+        store.updateTopSkill(0, updatedSkill);
+        expect(store.topSkills[0]).toEqual(updatedSkill);
+    });
+
+    it('removeTopSkill action removes a top skill', () => {
+        const store = useResumeStore();
+        store.clearTopSkills();
+        const skill = { name: 'JavaScript', yearsOfExperience: 5 };
+        store.addTopSkill(skill);
+        expect(store.topSkills).toEqual([skill]);
+        store.removeTopSkill(0);
+        expect(store.topSkills).toEqual([]);
+    });
+
+    it('sortTopSkills action sorts top skills by years of experience', () => {
+        const store = useResumeStore();
+        const skills = [
+            { name: 'JavaScript', yearsOfExperience: 5 },
+            { name: 'TypeScript', yearsOfExperience: 3 },
+            { name: 'Vue', yearsOfExperience: 2 },
+        ];
+        store.topSkills = skills;
+        store.sortTopSkills();
+        expect(store.topSkills).toEqual([skills[0], skills[1], skills[2]]);
+    });
+
+    it('clearTopSkills action clears top skills', () => {
+        const store = useResumeStore();
+        const skills = [
+            { name: 'JavaScript', yearsOfExperience: 5 },
+            { name: 'TypeScript', yearsOfExperience: 3 },
+            { name: 'Vue', yearsOfExperience: 2 },
+        ];
+        store.topSkills = skills;
+        store.clearTopSkills();
+        expect(store.topSkills).toEqual([]);
     });
 });

--- a/src/stores/resume.ts
+++ b/src/stores/resume.ts
@@ -97,7 +97,10 @@ export const useResumeStore = defineStore('resume', {
     },
     actions: {
         reset() {
-            Object.assign(this, defaultResumeState);
+            // this.$state = { ...defaultResumeState };
+            this.general = { ...defaultResumeState.general };
+            this.skills = { ...defaultResumeState.skills };
+            this.topSkills = [];
         },
         async updateProfilePhoto(profilePhoto: File) {
             try {
@@ -107,6 +110,9 @@ export const useResumeStore = defineStore('resume', {
             } catch (error) {
                 console.error('Error processing profile photo:', error);
             }
+        },
+        clearProfilePhoto() {
+            this.general.profilePhoto = '';
         },
         updateName(name: Name) {
             this.general.name = name;
@@ -170,6 +176,9 @@ export const useResumeStore = defineStore('resume', {
         },
         sortTopSkills() {
             this.topSkills.sort((a, b) => b.yearsOfExperience - a.yearsOfExperience);
+        },
+        clearTopSkills() {
+            this.topSkills = [];
         },
     },
 });

--- a/src/stores/resume.ts
+++ b/src/stores/resume.ts
@@ -80,20 +80,6 @@ export const useResumeStore = defineStore('resume', {
             const { firstName = '', middleName = '', lastName = '' } = state.general.name || {};
             return [firstName, middleName, lastName].filter(Boolean).join(' ').trim();
         },
-        profilePhotoUrl: (state) => {
-            const profilePhoto = state.general.profilePhoto;
-
-            if (typeof profilePhoto === 'string') {
-                return profilePhoto;
-            }
-
-            if (typeof profilePhoto === 'object' && Object.keys(profilePhoto).length === 0) {
-                console.error('Profile photo is an empty object');
-                return '';
-            }
-
-            return profilePhoto ? URL.createObjectURL(profilePhoto) : undefined;
-        },
     },
     actions: {
         reset() {
@@ -104,6 +90,10 @@ export const useResumeStore = defineStore('resume', {
         },
         async updateProfilePhoto(profilePhoto: File) {
             try {
+                if (!profilePhoto.type.startsWith('image/')) {
+                    throw new Error('File is not an image');
+                }
+
                 const base64 = await convertImageToBase64(profilePhoto);
                 const roundedBase64 = await roundImage(base64, 200, 200);
                 this.general.profilePhoto = roundedBase64;

--- a/src/utils/__tests__/IntroductionPage.spec.ts
+++ b/src/utils/__tests__/IntroductionPage.spec.ts
@@ -1,14 +1,72 @@
-import './setupTests';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import IntroductionPage from '../resume/IntroductionPage';
 import { createPinia, setActivePinia } from 'pinia';
 import { PDFDocument } from 'pdf-lib';
 import { PAGE_HEIGHT, PAGE_WIDTH } from '../resume/constants';
 import { useResumeStore } from '@/stores/resume';
+import { nextTick } from 'vue';
 
 vi.mock('../image', () => ({
     base64ToUint8Array: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
 }));
+
+vi.mock('@/stores/resume', () => {
+    const mockStore = {
+        general: {
+            name: {
+                firstName: 'Jon',
+                middleName: '',
+                lastName: 'Snow',
+                displayName: '',
+            },
+            profilePhoto: 'data:image/jpeg;base64,',
+            region: 'The Wall',
+            contact: {
+                email: 'jon.snow@resume-maker.io',
+                phone: '123123123',
+            },
+            drivingLicense: 'Car',
+            functionTitle: 'Watch Commander',
+            introduction: 'I am the sword in the darkness.',
+            achievements: ['Defeated the Night King', 'Knows nothing', 'King in the North'],
+            colleaguesDescribe: 'Brave',
+            colleaguesKnow: 'Loyal',
+        },
+        skills: {
+            languages: [],
+            frameworks: [],
+            platforms: [],
+            methodologies: [],
+            databases: [],
+            tools: [],
+            operatingSystems: [],
+        },
+        topSkills: [
+            {
+                name: 'JavaScript',
+                yearsOfExperience: 10,
+            },
+            {
+                name: 'TypeScript',
+                yearsOfExperience: 6,
+            },
+        ],
+        reset: vi.fn(() => {
+            mockStore.general.profilePhoto = '';
+            mockStore.general.name.firstName = '';
+            mockStore.general.name.lastName = '';
+        }),
+        clearTopSkills: vi.fn(() => {
+            mockStore.topSkills = [];
+        }),
+        addTopSkill: vi.fn(),
+        clearProfilePhoto: vi.fn(),
+    };
+
+    return {
+        useResumeStore: () => mockStore,
+    };
+});
 
 describe('IntroductionPage', () => {
     async function getPdfDocumentWithMocks(): Promise<PDFDocument> {
@@ -16,6 +74,7 @@ describe('IntroductionPage', () => {
         const page = {
             drawImage: vi.fn().mockResolvedValue({}),
             drawText: vi.fn().mockResolvedValue({}),
+            drawRectangle: vi.fn().mockResolvedValue({}),
             getHeight: vi.fn().mockReturnValue(841.89),
         };
 
@@ -83,7 +142,7 @@ describe('IntroductionPage', () => {
             height: 140,
         });
 
-        expect(page.drawText).toHaveBeenCalledTimes(6);
+        expect(page.drawText).toHaveBeenCalledTimes(9);
 
         expect(page.drawText).toHaveBeenCalledWith('First Name', expect.any(Object));
         expect(page.drawText).toHaveBeenCalledWith(store.general.name.firstName, expect.any(Object));
@@ -93,9 +152,55 @@ describe('IntroductionPage', () => {
 
         expect(page.drawText).toHaveBeenCalledWith('Driving License', expect.any(Object));
         expect(page.drawText).toHaveBeenCalledWith(store.general.drivingLicense, expect.any(Object));
+
+        expect(page.drawText).toHaveBeenCalledWith('Skills (experience in years)', expect.any(Object));
+        expect(page.drawText).toHaveBeenCalledWith(store.topSkills[0].name, expect.any(Object));
+        expect(page.drawText).toHaveBeenCalledWith(store.topSkills[1].name, expect.any(Object));
+
+        expect(page.drawRectangle).toHaveBeenCalledTimes(store.topSkills.length * 2);
     });
 
     it('should render correct data on the right column', () => {
         expect(1).toBe(1);
+    });
+
+    describe('test empty store', () => {
+        let store: ReturnType<typeof useResumeStore>;
+
+        beforeEach(() => {
+            setActivePinia(createPinia());
+            store = useResumeStore();
+
+            store.reset();
+        });
+
+        it('should not render profile photo if it is not set', async () => {
+            const introductionPage = IntroductionPage.getInstance();
+            introductionPage.drawRightColumn = vi.fn();
+
+            const pdfDoc = await getPdfDocumentWithMocks();
+
+            const page = pdfDoc.addPage();
+            (page.drawImage as Mock).mockReset();
+
+            await introductionPage.initialize(pdfDoc);
+            expect(page.drawImage).not.toHaveBeenCalled();
+        });
+
+        it('should not render top skills if they are not set', async () => {
+            const introductionPage = IntroductionPage.getInstance();
+            introductionPage.drawRightColumn = vi.fn();
+
+            const pdfDoc = await getPdfDocumentWithMocks();
+
+            const page = pdfDoc.addPage();
+            (page.drawRectangle as Mock).mockReset();
+            store.clearTopSkills();
+
+            await nextTick();
+            await introductionPage.initialize(pdfDoc);
+
+            expect(page.drawRectangle).not.toHaveBeenCalled();
+        });
     });
 });

--- a/src/utils/__tests__/SkillsPage.spec.ts
+++ b/src/utils/__tests__/SkillsPage.spec.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { PDFDocument } from 'pdf-lib';
+import { PAGE_HEIGHT, PAGE_WIDTH } from '../resume/constants';
+import SkillsPage from '../resume/SkillsPage';
+
+vi.mock('@/stores/resume', () => {
+    const mockStore = {
+        general: {
+            name: {
+                firstName: 'Jon',
+                middleName: '',
+                lastName: 'Snow',
+                displayName: '',
+            },
+            profilePhoto: 'data:image/jpeg;base64,',
+            region: 'The Wall',
+            contact: {
+                email: 'jon.snow@resume-maker.io',
+                phone: '123123123',
+            },
+            drivingLicense: 'Car',
+            functionTitle: 'Watch Commander',
+            introduction: 'I am the sword in the darkness.',
+            achievements: ['Defeated the Night King', 'Knows nothing', 'King in the North'],
+            colleaguesDescribe: 'Brave',
+            colleaguesKnow: 'Loyal',
+        },
+        skills: {
+            languages: ['JavaScript', 'TypeScript'],
+            frameworks: ['Vue.js', 'React'],
+            platforms: ['Node.js', 'Docker'],
+            methodologies: ['Agile', 'Scrum'],
+            databases: ['MongoDB', 'PostgreSQL'],
+            tools: ['Git', 'Docker'],
+            operatingSystems: ['Windows', 'Linux'],
+        },
+    };
+
+    return {
+        useResumeStore: () => mockStore,
+    };
+});
+
+describe('SkillsPage', () => {
+    async function getPdfDocumentWithMocks(): Promise<PDFDocument> {
+        const pdfDoc = await PDFDocument.create();
+        const page = {
+            drawImage: vi.fn().mockResolvedValue({}),
+            drawText: vi.fn().mockResolvedValue({}),
+            drawLine: vi.fn().mockResolvedValue({}),
+            getHeight: vi.fn().mockReturnValue(841.89),
+            getWidth: vi.fn().mockReturnValue(595.28),
+        };
+
+        pdfDoc.embedJpg = vi.fn().mockResolvedValue([1, 2, 3]);
+        pdfDoc.addPage = vi.fn().mockReturnValue(page);
+
+        return pdfDoc;
+    }
+
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it('should throw an error if PDFDocument is null', async () => {
+        const skillsPage = SkillsPage.getInstance();
+        await expect(async () => {
+            await skillsPage.initialize(null as unknown as PDFDocument);
+        }).rejects.toThrow('PDFDocument is not set');
+    });
+
+    it('should add a page on initialize', async () => {
+        const skillsPage = SkillsPage.getInstance();
+        const pdfDoc = await getPdfDocumentWithMocks();
+
+        await skillsPage.initialize(pdfDoc);
+
+        expect(pdfDoc.addPage).toHaveBeenCalledOnce();
+        expect(pdfDoc.addPage).toHaveBeenCalledWith([PAGE_WIDTH, PAGE_HEIGHT]);
+    });
+
+    it('should draw a title with an underline across the full width of the page', async () => {
+        const skillsPage = SkillsPage.getInstance();
+
+        const backupDrawLeftColumn = skillsPage.drawLeftColumn;
+        const backupDrawRightColumn = skillsPage.drawRightColumn;
+
+        skillsPage.drawLeftColumn = vi.fn();
+        skillsPage.drawRightColumn = vi.fn();
+
+        const pdfDoc = await getPdfDocumentWithMocks();
+
+        await skillsPage.initialize(pdfDoc);
+
+        const page = pdfDoc.addPage();
+
+        expect(page.drawLine).toHaveBeenCalledOnce();
+
+        expect(skillsPage.drawLeftColumn).toHaveBeenCalledOnce();
+        expect(skillsPage.drawRightColumn).toHaveBeenCalledOnce();
+
+        skillsPage.drawLeftColumn = backupDrawLeftColumn;
+        skillsPage.drawRightColumn = backupDrawRightColumn;
+    });
+
+    it('should draw the correct skill categories in the left column', async () => {
+        const skillsPage = SkillsPage.getInstance();
+
+        const backupDrawRightColumn = skillsPage.drawRightColumn;
+        skillsPage.drawRightColumn = vi.fn();
+
+        const pdfDoc = await getPdfDocumentWithMocks();
+
+        await skillsPage.initialize(pdfDoc);
+
+        const page = pdfDoc.addPage();
+
+        expect(page.drawLine).toHaveBeenCalledTimes(4);
+        expect(page.drawText).toHaveBeenCalledTimes(10);
+
+        skillsPage.drawRightColumn = backupDrawRightColumn;
+    });
+
+    it('should draw the correct skill categories in the right column', async () => {
+        const skillsPage = SkillsPage.getInstance();
+
+        const backupDrawLeftColumn = skillsPage.drawLeftColumn;
+        skillsPage.drawLeftColumn = vi.fn();
+
+        const pdfDoc = await getPdfDocumentWithMocks();
+
+        await skillsPage.initialize(pdfDoc);
+
+        const page = pdfDoc.addPage();
+
+        expect(page.drawLine).toHaveBeenCalledTimes(5);
+        expect(page.drawText).toHaveBeenCalledTimes(13);
+
+        skillsPage.drawLeftColumn = backupDrawLeftColumn;
+    });
+});

--- a/src/utils/__tests__/resume.spec.ts
+++ b/src/utils/__tests__/resume.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, type Mock } from 'vitest';
+import IntroductionPage from '../resume/IntroductionPage';
+import SkillsPage from '../resume/SkillsPage';
+import { generateResume } from '../resume/resume';
+import { PDFDocument } from 'pdf-lib';
+import { beforeEach } from 'vitest';
+
+vi.mock('pdf-lib', () => {
+    return {
+        PDFDocument: {
+            create: vi.fn().mockResolvedValue({
+                save: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+            }),
+        },
+    };
+});
+
+vi.mock('../resume/IntroductionPage', () => {
+    return {
+        default: {
+            getInstance: vi.fn().mockReturnValue({
+                initialize: vi.fn(),
+            }),
+        },
+    };
+});
+
+vi.mock('../resume/SkillsPage', () => {
+    return {
+        default: {
+            getInstance: vi.fn().mockReturnValue({
+                initialize: vi.fn(),
+            }),
+        },
+    };
+});
+
+describe('generateResume', () => {
+    beforeEach(() => {
+        (IntroductionPage.getInstance().initialize as Mock).mockReset();
+        (SkillsPage.getInstance().initialize as Mock).mockReset();
+    });
+
+    it('should create and save a PDF', async () => {
+        await generateResume();
+
+        const pdfDoc = await PDFDocument.create();
+        expect((await pdfDoc).save).toHaveBeenCalledOnce();
+    });
+
+    it('should do initialize the page classes', async () => {
+        const introductionPage = IntroductionPage.getInstance();
+        const skillsPage = SkillsPage.getInstance();
+
+        await generateResume();
+
+        expect(introductionPage.initialize).toHaveBeenCalledOnce();
+        expect(skillsPage.initialize).toHaveBeenCalledOnce();
+    });
+});

--- a/src/utils/__tests__/setupTests.ts
+++ b/src/utils/__tests__/setupTests.ts
@@ -28,6 +28,15 @@ export const resumeInitialState: ResumeData = {
         tools: [],
         operatingSystems: [],
     },
-    topSkills: [],
+    topSkills: [
+        {
+            name: 'JavaScript',
+            yearsOfExperience: 10,
+        },
+        {
+            name: 'TypeScript',
+            yearsOfExperience: 6,
+        },
+    ],
 };
 localStorage.setItem('resumeData', JSON.stringify(resumeInitialState));

--- a/src/utils/resume/IntroductionPage.ts
+++ b/src/utils/resume/IntroductionPage.ts
@@ -6,10 +6,6 @@ import { SPACING } from './constants';
 export default class IntroductionPage extends Page {
     static #instance: IntroductionPage | null = null;
 
-    #generalData: General = this.resumeStore.general;
-
-    #topSkillsData: TopSkill[] = this.resumeStore.topSkills;
-
     public static getInstance(): IntroductionPage {
         if (this.#instance === null) {
             this.#instance = new IntroductionPage();
@@ -23,10 +19,6 @@ export default class IntroductionPage extends Page {
     }
 
     public async initialize(pdfDoc: PDFDocument): Promise<void> {
-        if (!pdfDoc) {
-            throw new Error('PDFDocument is not set');
-        }
-
         await super.initialize(pdfDoc);
 
         await this.drawLeftColumn();
@@ -36,13 +28,34 @@ export default class IntroductionPage extends Page {
     public async drawLeftColumn() {
         super.drawLeftColumn();
 
-        const DEFINITION_COLUMN_X = 172;
+        await this.#drawProfilePhoto();
+        this.#drawDefinitionColumn();
+        this.#drawTopSkills();
+    }
 
-        if (this.#generalData.profilePhoto) {
-            this.currentY += await this.drawImage(this.#generalData.profilePhoto, 140, 140);
+    public async drawRightColumn() {
+        super.drawRightColumn();
+
+        this.#drawName();
+        this.#drawFunctionTitle();
+        this.#drawIntroduction();
+        this.#drawAchievements();
+        this.#drawColleaguesDescribe();
+        this.#drawColleaguesKnow();
+    }
+
+    async #drawProfilePhoto(): Promise<void> {
+        if (!this.resumeStore.general.profilePhoto) {
+            return;
         }
 
-        if (this.#generalData.name?.firstName) {
+        this.currentY += await this.drawImage(this.resumeStore.general.profilePhoto, 140, 140);
+    }
+
+    #drawDefinitionColumn(): void {
+        const DEFINITION_COLUMN_X = 172;
+
+        if (this.resumeStore.general.name?.firstName) {
             this.drawText({
                 text: getLocalizedString('firstName'),
                 size: this.textSize,
@@ -52,7 +65,7 @@ export default class IntroductionPage extends Page {
             });
 
             this.currentY += this.drawText({
-                text: this.#generalData.name.firstName,
+                text: this.resumeStore.general.name.firstName,
                 size: this.textSize,
                 font: this.textFont,
                 y: this.currentY,
@@ -60,7 +73,7 @@ export default class IntroductionPage extends Page {
             });
         }
 
-        if (this.#generalData.region) {
+        if (this.resumeStore.general.region) {
             this.drawText({
                 text: getLocalizedString('region'),
                 size: this.textSize,
@@ -70,7 +83,7 @@ export default class IntroductionPage extends Page {
             });
 
             this.currentY += this.drawText({
-                text: this.#generalData.region,
+                text: this.resumeStore.general.region,
                 size: this.textSize,
                 font: this.textFont,
                 y: this.currentY,
@@ -78,7 +91,7 @@ export default class IntroductionPage extends Page {
             });
         }
 
-        if (this.#generalData.drivingLicense) {
+        if (this.resumeStore.general.drivingLicense) {
             this.drawText({
                 text: getLocalizedString('drivingLicense'),
                 size: this.textSize,
@@ -88,34 +101,36 @@ export default class IntroductionPage extends Page {
             });
 
             this.currentY += this.drawText({
-                text: this.#generalData.drivingLicense,
+                text: this.resumeStore.general.drivingLicense,
                 size: this.textSize,
                 font: this.textFont,
                 y: this.currentY,
                 x: DEFINITION_COLUMN_X,
             });
         }
-
-        if (this.#topSkillsData.length) {
-            this.currentY += SPACING;
-
-            this.currentY += this.drawText({
-                text: getLocalizedString('topSkillsTitle'),
-                size: this.textSize,
-                font: this.titleFont,
-                y: this.currentY,
-                x: this.currentX,
-                centerText: true,
-            });
-
-            this.drawSkillsChart(this.#topSkillsData, this.textSize);
-        }
     }
 
-    public async drawRightColumn() {
-        super.drawRightColumn();
+    #drawTopSkills(): void {
+        if (this.resumeStore.topSkills.length === 0) {
+            return;
+        }
 
-        if (this.#generalData.name) {
+        this.currentY += SPACING;
+
+        this.currentY += this.drawText({
+            text: getLocalizedString('topSkillsTitle'),
+            size: this.textSize,
+            font: this.titleFont,
+            y: this.currentY,
+            x: this.currentX,
+            centerText: true,
+        });
+
+        this.drawSkillsChart(this.resumeStore.topSkills, this.textSize);
+    }
+
+    #drawName(): void {
+        if (this.resumeStore.general.name) {
             this.drawField({
                 title: this.resumeStore.formattedName,
                 text: '',
@@ -123,41 +138,51 @@ export default class IntroductionPage extends Page {
                 centerText: true,
             });
         }
+    }
 
-        if (this.#generalData.functionTitle) {
+    #drawFunctionTitle(): void {
+        if (this.resumeStore.general.functionTitle) {
             this.drawField({
-                title: this.#generalData.functionTitle,
+                title: this.resumeStore.general.functionTitle,
                 centerText: true,
             });
         }
+    }
 
-        if (this.#generalData.introduction) {
+    #drawIntroduction(): void {
+        if (this.resumeStore.general.introduction) {
             this.drawField({
-                text: this.#generalData.introduction,
+                text: this.resumeStore.general.introduction,
                 needsSpacing: true,
             });
         }
+    }
 
-        if (this.#generalData.achievements) {
+    #drawAchievements(): void {
+        if (this.resumeStore.general.achievements) {
             this.drawField({
                 title: getLocalizedString('achievements'),
-                bulletList: this.#generalData.achievements,
+                bulletList: this.resumeStore.general.achievements,
                 needsSpacing: true,
             });
         }
+    }
 
-        if (this.#generalData.colleaguesDescribe) {
+    #drawColleaguesDescribe(): void {
+        if (this.resumeStore.general.colleaguesDescribe) {
             this.drawField({
                 title: getLocalizedString('colleaguesDescribeTitle'),
-                text: this.#generalData.colleaguesDescribe,
+                text: this.resumeStore.general.colleaguesDescribe,
                 needsSpacing: true,
             });
         }
+    }
 
-        if (this.#generalData.colleaguesKnow) {
+    #drawColleaguesKnow(): void {
+        if (this.resumeStore.general.colleaguesKnow) {
             this.drawField({
                 title: getLocalizedString('colleaguesKnowTitle'),
-                text: this.#generalData.colleaguesKnow,
+                text: this.resumeStore.general.colleaguesKnow,
                 needsSpacing: true,
             });
         }

--- a/src/utils/resume/Page.ts
+++ b/src/utils/resume/Page.ts
@@ -35,6 +35,10 @@ export default class Page {
     };
 
     public async initialize(pdfDoc: PDFDocument): Promise<void> {
+        if (!pdfDoc) {
+            throw new Error('PDFDocument is not set');
+        }
+
         this.#document = pdfDoc;
         this.page = this.addPage();
 
@@ -68,14 +72,6 @@ export default class Page {
 
     protected drawField(props: FieldData): number {
         let totalAddedHeight = 0;
-
-        if (this.page === null) {
-            throw new Error('Page not initialized');
-        }
-
-        if (this.titleFont === null || this.textFont === null) {
-            throw new Error('Fonts not initialized');
-        }
 
         if (props.needsSpacing) {
             this.currentY += SPACING;

--- a/src/utils/resume/SkillsPage.ts
+++ b/src/utils/resume/SkillsPage.ts
@@ -6,7 +6,7 @@ import { rgb, type PDFDocument } from 'pdf-lib';
 export default class SkillsPage extends Page {
     static #instance: SkillsPage | null = null;
 
-    #data: Skills;
+    #data: Skills = this.resumeStore.skills;
 
     public static getInstance(): SkillsPage {
         if (this.#instance === null) {
@@ -18,8 +18,6 @@ export default class SkillsPage extends Page {
 
     private constructor() {
         super();
-
-        this.#data = this.resumeStore.skills;
     }
 
     public async initialize(pdfDoc: PDFDocument): Promise<void> {
@@ -30,13 +28,13 @@ export default class SkillsPage extends Page {
         await this.drawRightColumn();
     }
 
-    protected drawFullWidth(): void {
+    public drawFullWidth(): void {
         super.drawFullWidth();
 
         this.#renderUnderlinedTitle(getLocalizedString('technicalSkills'));
     }
 
-    protected drawLeftColumn(): void {
+    public drawLeftColumn(): void {
         this.currentX = HORIZONTAL_EDGE_SPACING;
         this.currentY = VERTICAL_EDGE_SPACING + 25.4;
 
@@ -45,7 +43,7 @@ export default class SkillsPage extends Page {
         this.#renderSkillsTable(getLocalizedString('tools'), this.#data.tools);
     }
 
-    protected drawRightColumn(): void {
+    public drawRightColumn(): void {
         this.currentX = RIGHT_COLUMN_START;
         this.currentY = VERTICAL_EDGE_SPACING + 25.4;
 


### PR DESCRIPTION
Added a feature to mark top skills.

- The user is able to select a skill from the skills inputted previously for the skills table.
- For this skill the user can enter the years of experience they have with this skill
- Up to 10 "top skills" can be added.
- The user is able to sort the skills by years of experience.
- The top skills are drawn on the introduction page with "progress bars". The assumption was made that 10+ years is a full bar where you have mastered the skill. This is up for debate in the future.