### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
               run: npm run test:unit:coverage
 
             - name: Upload coverage report
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: coverage-report
                   path: coverage/


### PR DESCRIPTION
## Summary
- use `actions/upload-artifact@v4` in the unit test workflow

## Testing
- `npm run test:unit:coverage` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684572adee8c832c8b44f2a392f1f27f