### PR TITLE
Fix comment for parseDateFromString

### DIFF
--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -19,7 +19,8 @@ export function formatDateToLocale(passedDate: Date | string, locale?: string): 
 /**
  * Converts a string in "YYYY-MM-DD" format to a Date object.
  * @param dateString - The date string in "YYYY-MM-DD" format.
- * @returns A Date object or null if the input is invalid.
+ * @returns A Date object.
+ * @throws Error if the date string is invalid.
  */
 export function parseDateFromString(dateString: string): Date {
     const [year, month, day] = dateString.split('-').map(Number);


### PR DESCRIPTION
## Summary
- clarify that `parseDateFromString` throws when the date string is invalid

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684571fc3768832c9388d59b36d1d6d3