### PR TITLE
Improve e2e selector

### DIFF
--- a/e2e/vue.spec.ts
+++ b/e2e/vue.spec.ts
@@ -3,11 +3,12 @@ import { getDummyResume } from '../src/utils/dummyResume'
 
 // See here how to get started:
 // https://playwright.dev/docs/intro
+const RESUME_DATA_KEY = 'resumeData';
+
 test('shows resume preview and general form fields', async ({ page }) => {
     await page.addInitScript((resume) => {
-        localStorage.setItem('resumeData', resume)
+        localStorage.setItem(RESUME_DATA_KEY, resume)
     }, JSON.stringify(getDummyResume()))
-
     await page.goto('/')
 
     // Resume preview should render when resume data is available

--- a/e2e/vue.spec.ts
+++ b/e2e/vue.spec.ts
@@ -1,8 +1,19 @@
 import { test, expect } from '@playwright/test'
+import { getDummyResume } from '../src/utils/dummyResume'
 
 // See here how to get started:
 // https://playwright.dev/docs/intro
-test('visits the app root url', async ({ page }) => {
+test('shows resume preview and general form fields', async ({ page }) => {
+    await page.addInitScript((resume) => {
+        localStorage.setItem('resumeData', resume)
+    }, JSON.stringify(getDummyResume()))
+
     await page.goto('/')
-    await expect(page.locator('div.greetings > h1')).toHaveText('You did it!')
+
+    // Resume preview should render when resume data is available
+    await expect(page.locator('.resume-preview')).toBeVisible()
+
+    // General tab should contain the required name fields
+    await expect(page.locator('input#firstName')).toBeVisible()
+    await expect(page.locator('input#lastName')).toBeVisible()
 })


### PR DESCRIPTION
## Summary
- assert resume preview visibility
- check first and last name fields on the general tab

## Testing
- `npx playwright install` *(fails: 403 Forbidden)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684572032658832cabed844b043b3900